### PR TITLE
Changes the tests to not run the demo program

### DIFF
--- a/assertions_test.go
+++ b/assertions_test.go
@@ -1,0 +1,63 @@
+package clapper
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func fail(t *testing.T) {
+	_, f, l, _ := runtime.Caller(2)
+	fmt.Printf("%s # %d\n", f, l)
+	t.FailNow()
+}
+
+func toErrorS(msg ...interface{}) (s string) {
+	args := msg[0].([]interface{})
+	if len(args) > 0 {
+		if fs, ok := args[0].(string); ok {
+			if len(args) > 1 {
+				s = fmt.Sprintf(": %s", fmt.Sprintf(fs, args[1:]...))
+			} else {
+				s = fs
+			}
+		}
+	}
+	return s
+}
+
+func assertError(t *testing.T, v error, msg ...interface{}) {
+	if v == nil {
+		t.Errorf("expected error%s", toErrorS(msg))
+		fail(t)
+	}
+}
+
+func assertNoError(t *testing.T, v error, msg ...interface{}) {
+	if v != nil {
+		t.Errorf("expected no error%s", toErrorS(msg))
+		fail(t)
+	}
+}
+
+func assertEqual(t *testing.T, a interface{}, b interface{}, msg ...interface{}) {
+	if a != b {
+		t.Errorf("expected %v, got %v%s", a, b, toErrorS(msg))
+		fail(t)
+	}
+}
+
+func assertNil(t *testing.T, a interface{}, msg ...interface{}) {
+	if a != nil {
+		t.Errorf("expected nil, got %v%s", a, toErrorS(msg))
+		fail(t)
+	}
+}
+
+func assertNotNil(t *testing.T, a interface{}, msg ...interface{}) {
+	if a == nil || (reflect.ValueOf(a).Kind() == reflect.Ptr && reflect.ValueOf(a).IsNil()) {
+		t.Errorf("expected not nil, got %v%s", a, toErrorS(msg))
+		fail(t)
+	}
+}

--- a/clapper_test.go
+++ b/clapper_test.go
@@ -2,146 +2,192 @@ package clapper
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
 	"strings"
 	"testing"
 )
+
+// This entire suite would be far easier with testify
+
+var tests []struct {
+	subCommand string
+	arg        string
+	longName   string
+	shortName  string
+	isBool     bool
+	defaultVal string
+}
+
+func setup(t *testing.T, args []string) (*CommandConfig, error) {
+	tests = []struct {
+		subCommand string
+		arg        string
+		longName   string
+		shortName  string
+		isBool     bool
+		defaultVal string
+	}{
+		{"", "output", "", "", false, ""},
+		{"", "", "force", "f", true, ""},
+		{"", "", "verbose", "v", true, ""},
+		{"", "", "version", "V", false, ""},
+		{"", "", "dir", "", false, "/var/users"},
+		{"info", "category", "", "", false, "manager"},
+		{"info", "username", "", "", false, ""},
+		{"info", "subjects...", "", "", false, ""},
+		{"info", "", "verbose", "v", true, ""},
+		{"info", "", "version", "V", false, "1.0.1"},
+		{"info", "", "output", "o", false, "./"},
+		{"info", "", "no-clean", "", true, ""},
+		{"ghost", "", "", "", false, ""},
+	}
+
+	reg := NewRegistry()
+	subs := make(map[string]*CommandConfig)
+	for _, test := range tests {
+		sub := subs[test.subCommand]
+		if sub == nil {
+			sub, _ = reg.Register(test.subCommand)
+			subs[test.subCommand] = sub
+		}
+		if test.longName != "" {
+			sub.AddFlag(test.longName, test.shortName, test.isBool, test.defaultVal)
+		} else if test.arg != "" {
+			sub.AddArg(test.arg, test.defaultVal)
+		}
+	}
+
+	return reg.Parse(args)
+}
 
 /*----------------*/
 
 // test unsupported flag
 func TestUnsupportedAssignment(t *testing.T) {
 
-	// options
-	options := map[string][]string{
-		"---version": []string{"---version"},
-		"---v":       []string{"---v=1.0.0"},
-		"-version":   []string{"-version"},
+	tests := []struct {
+		flag     string
+		expected string
+		options  string
+		err      error
+	}{
+		{"---version", "---version", "---version", ErrorUnsupportedFlag{}},
+		{"---v", "---v", "---v=1.0.0", ErrorUnsupportedFlag{}},
+		// Single-dash for long names was never supported, but now this is interpreted as:
+		// -v -e -r -s -i -o -n; ergo, the error will be "unknown option '-e'"
+		{"-e", "-version", "-version", ErrorUnsupportedFlag{}},
 	}
 
-	for flag, options := range options {
-		// command
-		cmd := exec.Command("go", append([]string{"run", "demo/cmd.go"}, options...)...)
+	for _, test := range tests {
+		reg := NewRegistry()
+		root, _ := reg.Register("")
+		root.AddFlag("version", "v", true, "")
 
-		// get output
-		if output, err := cmd.Output(); err != nil {
-			fmt.Println("Error:", err)
-		} else {
-			if !strings.Contains(fmt.Sprintf("%s", output), fmt.Sprintf(`error => clapper.ErrorUnsupportedFlag{Name:"%s"}`, flag)) {
-				t.Fail()
+		_, err := reg.Parse([]string{test.options})
+		assertError(t, err, "(%s) %T", test.options, test.err)
+		if err != nil {
+			assertEqual(t, fmt.Sprintf("%T", err), fmt.Sprintf("%T", test.err))
+			var name string
+			switch e := err.(type) {
+			case ErrorUnknownFlag:
+				name = e.Name
+			case ErrorUnsupportedFlag:
+				name = e.Name
+			default:
+				assertError(t, err)
 			}
+			assertEqual(t, test.expected, name)
 		}
 	}
 }
 
 // test empty root command
 func TestEmptyRootCommand(t *testing.T) {
-	// command
-	cmd := exec.Command("go", "run", "demo/cmd.go")
+	cmd, err := setup(t, []string{})
 
-	// get output
-	if output, err := cmd.Output(); err != nil {
-		fmt.Println("Error:", err)
-	} else {
-		lines := []string{
-			`sub-command => ""`,
-			`argument(output) => &clapper.Arg{Name:"output", IsVariadic:false, DefaultValue:"", Value:""}`,
-			`flag(force) => &clapper.Flag{Name:"force", ShortName:"f", IsBoolean:true, IsInverted:false, DefaultValue:"false", Value:""}`,
-			`flag(verbose) => &clapper.Flag{Name:"verbose", ShortName:"v", IsBoolean:true, IsInverted:false, DefaultValue:"false", Value:""}`,
-			`flag(version) => &clapper.Flag{Name:"version", ShortName:"V", IsBoolean:false, IsInverted:false, DefaultValue:"", Value:""}`,
-			`flag(dir) => &clapper.Flag{Name:"dir", ShortName:"", IsBoolean:false, IsInverted:false, DefaultValue:"/var/users", Value:""}`,
+	assertNoError(t, err)
+	assertEqual(t, "", cmd.Name)
+	assertEqual(t, 1, len(cmd.Args))
+
+	if cmd.Args["output"] == nil {
+		for k := range cmd.Args {
+			t.Errorf("expected one \"output\" argument; got %s", k)
 		}
+	}
 
-		for _, line := range lines {
-			if !strings.Contains(fmt.Sprintf("%s", output), line) {
-				t.Fail()
+}
+
+func TestRootDefaults(t *testing.T) {
+	cmd, err := setup(t, []string{})
+
+	assertNoError(t, err)
+	assertEqual(t, "", cmd.Args["output"].Value)
+
+	for _, test := range tests {
+		if test.longName != "" && test.subCommand == "" {
+			f := cmd.Flags[test.longName]
+			assertNotNil(t, f, "missing flag %q", test.longName)
+			assertEqual(t, test.shortName, f.ShortName, "(%s)", test.longName)
+			assertEqual(t, test.isBool, f.IsBoolean, "(%s)", test.longName)
+			dv := test.defaultVal
+			if test.isBool && dv == "" {
+				dv = "false"
 			}
+			assertEqual(t, dv, f.DefaultValue, "(%+v %+v)", test, f)
 		}
 	}
 }
 
 // test root command when not registered
-func TestUnregisteredRootCommand(t *testing.T) {
-	// command
-	cmd := exec.Command("go", "run", "demo/cmd.go")
-	cmd.Env = append(os.Environ(), "NO_ROOT=TRUE")
-
-	// get output
-	if output, err := cmd.Output(); err != nil {
-		fmt.Println("Error:", err)
-	} else {
-		lines := []string{
-			`error => clapper.ErrorUnknownCommand{Name:""}`,
-		}
-
-		for _, line := range lines {
-			if !strings.Contains(fmt.Sprintf("%s", output), line) {
-				t.Fail()
-			}
-		}
-	}
-}
+// REMOVED This was testing code in the demo program, which had nothing to do with the library.
 
 // test an unregistered flag
 func TestUnregisteredFlag(t *testing.T) {
-
 	// flags
 	flags := map[string][]string{
-		"-d":          []string{"-V", "1.0.1", "-v", "--force", "-d", "./sub/dir"},
-		"--m":         []string{"-V", "1.0.1", "-v", "--force", "--m", "./sub/dir"},
-		"--directory": []string{"-V", "1.0.1", "-v", "--force", "--directory", "./sub/dir"},
+		"-d":          {"-V", "1.0.1", "-v", "--force", "-d", "./sub/dir"},
+		"--m":         {"-V", "1.0.1", "-v", "--force", "--m", "./sub/dir"},
+		"--directory": {"-V", "1.0.1", "-v", "--force", "--directory", "./sub/dir"},
 	}
 
 	for flag, options := range flags {
-		// command
-		cmd := exec.Command("go", append([]string{"run", "demo/cmd.go"}, options...)...)
-
-		// get output
-		if output, err := cmd.Output(); err != nil {
-			fmt.Println("Error:", err)
+		_, err := setup(t, options)
+		assertError(t, err)
+		if e, ok := err.(ErrorUnknownFlag); !ok {
+			t.Errorf("expected an ErrUnknownFlag; got %t", err)
 		} else {
-			if !strings.Contains(fmt.Sprintf("%s", output), fmt.Sprintf(`error => clapper.ErrorUnknownFlag{Name:"%s"}`, flag)) {
-				t.Fail()
-			}
+			assertEqual(t, flag, e.Name)
 		}
 	}
-
 }
 
 // test for valid inverted flag values
 func TestValidInvertFlagValues(t *testing.T) {
-
 	// options list
 	optionsList := [][]string{
-		[]string{"info", "student", "-V", "-v", "--output", "./opt/dir", "--no-clean"},
-		[]string{"info", "student", "--version", "--no-clean", "--output", "./opt/dir", "--verbose"},
+		{"info", "student", "-V", "-v", "--output", "./opt/dir", "--no-clean"},
+		{"info", "student", "--version", "--no-clean", "--output", "./opt/dir", "--verbose"},
+	}
+	expecteds := map[string]string{
+		"version": "",
+		"clean":   "false",
+		"output":  "./opt/dir",
+		"verbose": "true",
 	}
 
 	for _, options := range optionsList {
-		// command
-		cmd := exec.Command("go", append([]string{"run", "demo/cmd.go"}, options...)...)
-
-		// get output
-		if output, err := cmd.Output(); err != nil {
-			fmt.Println("Error:", err)
-		} else {
-			lines := []string{
-				`sub-command => "info"`,
-				`argument(category) => &clapper.Arg{Name:"category", IsVariadic:false, DefaultValue:"manager", Value:"student"}`,
-				`argument(username) => &clapper.Arg{Name:"username", IsVariadic:false, DefaultValue:"", Value:""}`,
-				`argument(subjects) => &clapper.Arg{Name:"subjects", IsVariadic:true, DefaultValue:"", Value:""}`,
-				`flag(version) => &clapper.Flag{Name:"version", ShortName:"V", IsBoolean:false, IsInverted:false, DefaultValue:"1.0.1", Value:""}`,
-				`flag(output) => &clapper.Flag{Name:"output", ShortName:"o", IsBoolean:false, IsInverted:false, DefaultValue:"./", Value:"./opt/dir"}`,
-				`flag(verbose) => &clapper.Flag{Name:"verbose", ShortName:"v", IsBoolean:true, IsInverted:false, DefaultValue:"false", Value:"true"}`,
-				`flag(clean) => &clapper.Flag{Name:"clean", ShortName:"", IsBoolean:true, IsInverted:true, DefaultValue:"true", Value:"false"}`,
+		cmd, err := setup(t, options)
+		assertNoError(t, err)
+		assertEqual(t, options[0], cmd.Name)
+		assertEqual(t, options[1], cmd.Args["category"].Value)
+		assertEqual(t, "", cmd.Args["username"].Value)
+		assertEqual(t, "", cmd.Args["subjects"].Value)
+		for _, opt := range options {
+			if strings.HasPrefix("--no", opt) && cmd.Flags[opt].IsInverted != true {
+				t.Errorf("expected inverted flag for %s", opt)
 			}
-
-			for _, line := range lines {
-				if !strings.Contains(fmt.Sprintf("%s", output), line) {
-					t.Fail()
-				}
-			}
+		}
+		for k, v := range expecteds {
+			assertEqual(t, v, cmd.Flags[k].Value)
 		}
 	}
 }
@@ -151,58 +197,39 @@ func TestErrorUnknownFlagForInvertFlags(t *testing.T) {
 
 	// options list
 	optionsList := map[string][]string{
-		"--clean":   []string{"info", "student", "-V", "-v", "--output", "./opt/dir", "--clean"},
-		"--no-dump": []string{"info", "student", "--version", "--no-dump", "--output", "./opt/dir", "--verbose"},
+		"--clean":   {"info", "student", "-V", "-v", "--output", "./opt/dir", "--clean"},
+		"--no-dump": {"info", "student", "--version", "--no-dump", "--output", "./opt/dir", "--verbose"},
 	}
 
 	for flag, options := range optionsList {
-		// command
-		cmd := exec.Command("go", append([]string{"run", "demo/cmd.go"}, options...)...)
-
-		// get output
-		if output, err := cmd.Output(); err != nil {
-			fmt.Println("Error:", err)
+		_, err := setup(t, options)
+		assertError(t, err)
+		if e, ok := err.(ErrorUnknownFlag); !ok {
+			t.Errorf("expected an ErrUnknownFlag; got %t", err)
 		} else {
-			if !strings.Contains(fmt.Sprintf("%s", output), fmt.Sprintf(`error => clapper.ErrorUnknownFlag{Name:"%s"}`, flag)) {
-				t.Fail()
-			}
+			assertEqual(t, flag, e.Name)
 		}
 	}
 }
 
 // test `--flag=value` syntax
 func TestFlagAssignmentSyntax(t *testing.T) {
-
 	// options list
 	optionsList := [][]string{
-		[]string{"info", "student", "-v", "--version=2.0.0", "thatisuday"},
-		[]string{"info", "student", "thatisuday", "-v", "-V=2.0.0"},
+		{"info", "student", "-v", "--version=2.0.0", "thatisuday"},
+		{"info", "student", "thatisuday", "-v", "-V=2.0.0"},
 	}
 
 	for _, options := range optionsList {
-		// command
-		cmd := exec.Command("go", append([]string{"run", "demo/cmd.go"}, options...)...)
-
-		// get output
-		if output, err := cmd.Output(); err != nil {
-			fmt.Println("Error:", err)
-		} else {
-			lines := []string{
-				`sub-command => "info"`,
-				`argument(category) => &clapper.Arg{Name:"category", IsVariadic:false, DefaultValue:"manager", Value:"student"}`,
-				`argument(username) => &clapper.Arg{Name:"username", IsVariadic:false, DefaultValue:"", Value:"thatisuday"}`,
-				`argument(subjects) => &clapper.Arg{Name:"subjects", IsVariadic:true, DefaultValue:"", Value:""}`,
-				`flag(version) => &clapper.Flag{Name:"version", ShortName:"V", IsBoolean:false, IsInverted:false, DefaultValue:"1.0.1", Value:"2.0.0"}`,
-				`flag(output) => &clapper.Flag{Name:"output", ShortName:"o", IsBoolean:false, IsInverted:false, DefaultValue:"./", Value:""}`,
-				`flag(verbose) => &clapper.Flag{Name:"verbose", ShortName:"v", IsBoolean:true, IsInverted:false, DefaultValue:"false", Value:"true"}`,
-			}
-
-			for _, line := range lines {
-				if !strings.Contains(fmt.Sprintf("%s", output), line) {
-					t.Fail()
-				}
-			}
-		}
+		cmd, err := setup(t, options)
+		assertNoError(t, err)
+		assertEqual(t, options[0], cmd.Name)
+		assertEqual(t, options[1], cmd.Args["category"].Value)
+		assertEqual(t, "thatisuday", cmd.Args["username"].Value)
+		assertEqual(t, "", cmd.Args["subjects"].Value)
+		assertEqual(t, "2.0.0", cmd.Flags["version"].Value)
+		assertEqual(t, "", cmd.Flags["output"].Value)
+		assertEqual(t, "true", cmd.Flags["verbose"].Value)
 	}
 }
 
@@ -211,35 +238,22 @@ func TestValidVariadicArgumentValues(t *testing.T) {
 
 	// options list
 	optionsList := [][]string{
-		[]string{"info", "student", "thatisuday", "-V", "-v", "--output", "./opt/dir", "--no-clean", "math", "science", "physics"},
-		[]string{"info", "student", "--version", "--no-clean", "thatisuday", "--output", "./opt/dir", "math", "science", "--verbose", "physics"},
+		{"info", "student", "thatisuday", "-V", "-v", "--output", "./opt/dir", "--no-clean", "math", "science", "physics"},
+		{"info", "student", "--version", "--no-clean", "thatisuday", "--output", "./opt/dir", "math", "science", "--verbose", "physics"},
 	}
 
 	for _, options := range optionsList {
-		// command
-		cmd := exec.Command("go", append([]string{"run", "demo/cmd.go"}, options...)...)
-
-		// get output
-		if output, err := cmd.Output(); err != nil {
-			fmt.Println("Error:", err)
-		} else {
-			lines := []string{
-				`sub-command => "info"`,
-				`argument(category) => &clapper.Arg{Name:"category", IsVariadic:false, DefaultValue:"manager", Value:"student"}`,
-				`argument(username) => &clapper.Arg{Name:"username", IsVariadic:false, DefaultValue:"", Value:"thatisuday"}`,
-				`argument(subjects) => &clapper.Arg{Name:"subjects", IsVariadic:true, DefaultValue:"", Value:"math,science,physics"}`,
-				`flag(version) => &clapper.Flag{Name:"version", ShortName:"V", IsBoolean:false, IsInverted:false, DefaultValue:"1.0.1", Value:""}`,
-				`flag(output) => &clapper.Flag{Name:"output", ShortName:"o", IsBoolean:false, IsInverted:false, DefaultValue:"./", Value:"./opt/dir"}`,
-				`flag(verbose) => &clapper.Flag{Name:"verbose", ShortName:"v", IsBoolean:true, IsInverted:false, DefaultValue:"false", Value:"true"}`,
-				`flag(clean) => &clapper.Flag{Name:"clean", ShortName:"", IsBoolean:true, IsInverted:true, DefaultValue:"true", Value:"false"}`,
-			}
-
-			for _, line := range lines {
-				if !strings.Contains(fmt.Sprintf("%s", output), line) {
-					t.Fail()
-				}
-			}
-		}
+		cmd, err := setup(t, options)
+		assertNoError(t, err)
+		assertEqual(t, options[0], cmd.Name)
+		assertEqual(t, options[1], cmd.Args["category"].Value)
+		assertEqual(t, "thatisuday", cmd.Args["username"].Value)
+		assertEqual(t, "math,science,physics", cmd.Args["subjects"].Value)
+		assertEqual(t, "", cmd.Flags["version"].Value)
+		assertEqual(t, "./opt/dir", cmd.Flags["output"].Value)
+		assertEqual(t, "true", cmd.Flags["verbose"].Value)
+		assertEqual(t, "false", cmd.Flags["clean"].Value)
+		assertEqual(t, true, cmd.Flags["clean"].IsInverted)
 	}
 }
 
@@ -250,107 +264,64 @@ func TestRootCommandWithOptions(t *testing.T) {
 
 	// options list
 	optionsList := [][]string{
-		[]string{"userinfo", "-V", "1.0.1", "-v", "--force", "--dir", "./sub/dir"},
-		[]string{"-V", "1.0.1", "--verbose", "--force", "userinfo", "--dir", "./sub/dir"},
-		[]string{"-V", "1.0.1", "-v", "--force", "--dir", "./sub/dir", "userinfo"},
-		[]string{"--version", "1.0.1", "--verbose", "--force", "--dir", "./sub/dir", "userinfo"},
+		{"userinfo", "-V", "1.0.1", "-v", "--force", "--dir", "./sub/dir"},
+		{"-V", "1.0.1", "--verbose", "--force", "userinfo", "--dir", "./sub/dir"},
+		{"-V", "1.0.1", "-v", "--force", "--dir", "./sub/dir", "userinfo"},
+		{"--version", "1.0.1", "--verbose", "--force", "--dir", "./sub/dir", "userinfo"},
 	}
 
 	for _, options := range optionsList {
-		// command
-		cmd := exec.Command("go", append([]string{"run", "demo/cmd.go"}, options...)...)
-
-		// get output
-		if output, err := cmd.Output(); err != nil {
-			fmt.Println("Error:", err)
-		} else {
-			lines := []string{
-				`sub-command => ""`,
-				`argument(output) => &clapper.Arg{Name:"output", IsVariadic:false, DefaultValue:"", Value:"userinfo"}`,
-				`flag(force) => &clapper.Flag{Name:"force", ShortName:"f", IsBoolean:true, IsInverted:false, DefaultValue:"false", Value:"true"}`,
-				`flag(verbose) => &clapper.Flag{Name:"verbose", ShortName:"v", IsBoolean:true, IsInverted:false, DefaultValue:"false", Value:"true"}`,
-				`flag(version) => &clapper.Flag{Name:"version", ShortName:"V", IsBoolean:false, IsInverted:false, DefaultValue:"", Value:"1.0.1"}`,
-				`flag(dir) => &clapper.Flag{Name:"dir", ShortName:"", IsBoolean:false, IsInverted:false, DefaultValue:"/var/users", Value:"./sub/dir"}`,
-			}
-
-			for _, line := range lines {
-				if !strings.Contains(fmt.Sprintf("%s", output), line) {
-					t.Fail()
-				}
-			}
-		}
+		cmd, err := setup(t, options)
+		assertNoError(t, err)
+		assertEqual(t, "", cmd.Name)
+		assertEqual(t, "userinfo", cmd.Args["output"].Value)
+		assertEqual(t, "true", cmd.Flags["force"].Value)
+		assertEqual(t, false, cmd.Flags["force"].IsInverted)
+		assertEqual(t, "true", cmd.Flags["verbose"].Value)
+		assertEqual(t, "1.0.1", cmd.Flags["version"].Value)
+		assertEqual(t, "./sub/dir", cmd.Flags["dir"].Value)
 	}
 }
 
 // test sub-command with options
 func TestSubCommandWithOptions(t *testing.T) {
-
 	// options list
 	optionsList := [][]string{
-		[]string{"info", "student", "-V", "-v", "--output", "./opt/dir"},
-		[]string{"info", "student", "--version", "--output", "./opt/dir", "--verbose"},
+		{"info", "student", "-V", "-v", "--output", "./opt/dir"},
+		{"info", "student", "--version", "--output", "./opt/dir", "--verbose"},
 	}
 
 	for _, options := range optionsList {
-		// command
-		cmd := exec.Command("go", append([]string{"run", "demo/cmd.go"}, options...)...)
-
-		// get output
-		if output, err := cmd.Output(); err != nil {
-			fmt.Println("Error:", err)
-		} else {
-			lines := []string{
-				`sub-command => "info"`,
-				`argument(category) => &clapper.Arg{Name:"category", IsVariadic:false, DefaultValue:"manager", Value:"student"}`,
-				`argument(username) => &clapper.Arg{Name:"username", IsVariadic:false, DefaultValue:"", Value:""}`,
-				`argument(subjects) => &clapper.Arg{Name:"subjects", IsVariadic:true, DefaultValue:"", Value:""}`,
-				`flag(version) => &clapper.Flag{Name:"version", ShortName:"V", IsBoolean:false, IsInverted:false, DefaultValue:"1.0.1", Value:""}`,
-				`flag(output) => &clapper.Flag{Name:"output", ShortName:"o", IsBoolean:false, IsInverted:false, DefaultValue:"./", Value:"./opt/dir"}`,
-				`flag(verbose) => &clapper.Flag{Name:"verbose", ShortName:"v", IsBoolean:true, IsInverted:false, DefaultValue:"false", Value:"true"}`,
-				`flag(clean) => &clapper.Flag{Name:"clean", ShortName:"", IsBoolean:true, IsInverted:true, DefaultValue:"true", Value:""}`,
-			}
-
-			for _, line := range lines {
-				if !strings.Contains(fmt.Sprintf("%s", output), line) {
-					t.Fail()
-				}
-			}
-		}
+		cmd, err := setup(t, options)
+		assertNoError(t, err)
+		assertEqual(t, "info", cmd.Name)
+		assertEqual(t, "student", cmd.Args["category"].Value)
+		assertEqual(t, "", cmd.Args["username"].Value)
+		assertEqual(t, "", cmd.Args["subjects"].Value)
+		assertEqual(t, "", cmd.Flags["version"].Value)
+		assertEqual(t, "./opt/dir", cmd.Flags["output"].Value)
+		assertEqual(t, "true", cmd.Flags["verbose"].Value)
+		assertEqual(t, "", cmd.Flags["clean"].Value)
 	}
 }
 
 // test sub-command with valid and extra arguments
 func TestSubCommandWithArguments(t *testing.T) {
-
 	// options list
 	optionsList := [][]string{
-		[]string{"info", "-v", "student", "-V", "2.0.0", "thatisuday"},
-		[]string{"info", "student", "-v", "thatisuday", "--version", "2.0.0"},
+		{"info", "-v", "student", "-V", "2.0.0", "thatisuday"},
+		{"info", "student", "-v", "thatisuday", "--version", "2.0.0"},
 	}
 
 	for _, options := range optionsList {
-		// command
-		cmd := exec.Command("go", append([]string{"run", "demo/cmd.go"}, options...)...)
-
-		// get output
-		if output, err := cmd.Output(); err != nil {
-			fmt.Println("Error:", err)
-		} else {
-			lines := []string{
-				`sub-command => "info"`,
-				`argument(category) => &clapper.Arg{Name:"category", IsVariadic:false, DefaultValue:"manager", Value:"student"}`,
-				`argument(username) => &clapper.Arg{Name:"username", IsVariadic:false, DefaultValue:"", Value:"thatisuday"}`,
-				`argument(subjects) => &clapper.Arg{Name:"subjects", IsVariadic:true, DefaultValue:"", Value:""}`,
-				`flag(version) => &clapper.Flag{Name:"version", ShortName:"V", IsBoolean:false, IsInverted:false, DefaultValue:"1.0.1", Value:"2.0.0"}`,
-				`flag(output) => &clapper.Flag{Name:"output", ShortName:"o", IsBoolean:false, IsInverted:false, DefaultValue:"./", Value:""}`,
-				`flag(verbose) => &clapper.Flag{Name:"verbose", ShortName:"v", IsBoolean:true, IsInverted:false, DefaultValue:"false", Value:"true"}`,
-			}
-
-			for _, line := range lines {
-				if !strings.Contains(fmt.Sprintf("%s", output), line) {
-					t.Fail()
-				}
-			}
-		}
+		cmd, err := setup(t, options)
+		assertNoError(t, err)
+		assertEqual(t, "info", cmd.Name)
+		assertEqual(t, "student", cmd.Args["category"].Value)
+		assertEqual(t, "thatisuday", cmd.Args["username"].Value)
+		assertEqual(t, "", cmd.Args["subjects"].Value)
+		assertEqual(t, "2.0.0", cmd.Flags["version"].Value)
+		assertEqual(t, "", cmd.Flags["output"].Value)
+		assertEqual(t, "true", cmd.Flags["verbose"].Value)
 	}
 }


### PR DESCRIPTION
The test suite was mostly testing the demo program; one test (`TestUnregisteredRootCommand`) *only* tested demo program behavior, without executing any checks on the core library.

This PR replaces all command-executions in tests with programmatic equivalents; it also removes the test for the demo program -- if that program were tested, it'd be best done in `demo/cmd_test.go`, not in the library.

Benchmarks show an improvement from 8.6 seconds per run to 500 milliseconds per run, or a 17x speed improvement. More importantly, the tests are more directly testing the library, not the demo program. Improvements are still possible; these tests are functional tests rather than unit tests.

Benchmark for pre-PR:
```
hyperfine 'go test . ; go clean -testcache' 
Benchmark 1: go test . ; go clean -testcache
  Time (mean ± σ):      8.601 s ±  2.788 s    [User: 10.870 s, System: 5.040 s]
  Range (min … max):    5.799 s … 13.011 s    10 runs
```

Post-PR:
```
10220(tests)⚡ » hyperfine 'go test . ; go clean -testcache' 
Benchmark 1: go test . ; go clean -testcache
  Time (mean ± σ):     503.5 ms ± 160.1 ms    [User: 849.9 ms, System: 325.8 ms]
  Range (min … max):   353.0 ms … 901.0 ms    10 runs
```